### PR TITLE
Internal orders add name to table and email search

### DIFF
--- a/source/modules/commerce/components/OrdersFilter.tsx
+++ b/source/modules/commerce/components/OrdersFilter.tsx
@@ -45,21 +45,12 @@ export function OrdersFilter(properties: OrdersFilterProperties) {
         properties.onFiltersChange({});
     }
 
-    // Function to format enum value for display
-    function formatStatusLabel(status: string): string {
-        // Add spaces before capital letters and handle special cases
-        return status
-            .replace(/([A-Z])/g, ' $1')
-            .replace(/^\s/, '')
-            .replace('Wait Payment', 'Waiting Payment');
-    }
-
     // Generate status options from enum
     const statusOptions = [
         { value: 'all', content: 'All Statuses' },
         ...Object.values(CommerceOrderStatus).map(status => ({
             value: status,
-            content: formatStatusLabel(status)
+            content: status
         }))
     ];
 
@@ -69,6 +60,7 @@ export function OrdersFilter(properties: OrdersFilterProperties) {
             <h3 className="mb-2  text-base font-medium">Search</h3>
             <div className="grid gap-4 md:grid-cols-4">
                 {/* Email Search */}
+                <div>
                     <label className="mb-1 block text-sm font-medium">Email</label>
                     <InputText
                         id="email-filter"

--- a/source/modules/commerce/components/OrdersFilter.tsx
+++ b/source/modules/commerce/components/OrdersFilter.tsx
@@ -1,0 +1,111 @@
+'use client'; // This component uses client-only features
+
+// Dependencies - React and Next.js
+import React from 'react';
+
+// Dependencies - Main Components
+import { Button } from '@structure/source/common/buttons/Button';
+import { InputText } from '@structure/source/common/forms/InputText';
+import { InputSelect } from '@structure/source/common/forms/InputSelect';
+
+// Dependencies - API
+import { CommerceOrderStatus } from '@structure/source/api/graphql/GraphQlGeneratedCode';
+
+// Dependencies - Assets
+import SearchIcon from '@structure/assets/icons/navigation/SearchIcon.svg';
+import FilterIcon from '@structure/assets/icons/interface/FilterIcon.svg';
+
+// Interface - OrdersFilterInterface
+export interface OrdersFilterInterface {
+    emailAddress?: string;
+    status?: CommerceOrderStatus;
+}
+
+// Component - OrdersFilter
+export interface OrdersFilterProperties {
+    onFiltersChange: (filters: OrdersFilterInterface) => void;
+}
+
+export function OrdersFilter(properties: OrdersFilterProperties) {
+    // State
+    const [emailAddress, setEmailAddress] = React.useState<string>('');
+    const [status, setStatus] = React.useState<string>('all');
+
+    // Functions
+    function handleApplyFilters() {
+        properties.onFiltersChange({
+            emailAddress: emailAddress.trim() || undefined,
+            status: status !== 'all' ? (status as CommerceOrderStatus) : undefined,
+        });
+    }
+
+    function handleReset() {
+        setEmailAddress('');
+        setStatus('all');
+        properties.onFiltersChange({});
+    }
+
+    // Function to format enum value for display
+    function formatStatusLabel(status: string): string {
+        // Add spaces before capital letters and handle special cases
+        return status
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/^\s/, '')
+            .replace('Wait Payment', 'Waiting Payment');
+    }
+
+    // Generate status options from enum
+    const statusOptions = [
+        { value: 'all', content: 'All Statuses' },
+        ...Object.values(CommerceOrderStatus).map(status => ({
+            value: status,
+            content: formatStatusLabel(status)
+        }))
+    ];
+
+    // Render the component
+    return (
+        <div className="mb-6 rounded-medium border border-neutral/10 bg-light p-4 dark:bg-dark+2">
+            <h3 className="mb-2  text-base font-medium">Search</h3>
+            <div className="grid gap-4 md:grid-cols-4">
+                {/* Email Search */}
+                    <label className="mb-1 block text-sm font-medium">Email</label>
+                    <InputText
+                        id="email-filter"
+                        placeholder="Enter email..."
+                        defaultValue={emailAddress}
+                        onChange={function (value) {
+                            setEmailAddress(value || '');
+                        }}
+                        onKeyDown={function (event) {
+                            if (event.key === 'Enter') {
+                                handleApplyFilters();
+                            }
+                        }}
+                        variant='search'
+                    />
+                </div>
+
+                {/* Status Filter */}
+                <div>
+                    <label className="mb-1 block text-sm font-medium">Status</label>
+                    <InputSelect
+                        items={statusOptions}
+                        defaultValue={status}
+                        onChange={function (value) {
+                            setStatus(value || 'all');
+                        }}
+                    />
+                </div>
+
+                {/* Buttons */}
+                <div className="flex items-end gap-2 md:col-span-2">
+                    <Button onClick={handleApplyFilters}>Search</Button>
+                    <Button variant="ghost" onClick={handleReset}>
+                        Reset
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/source/modules/commerce/components/OrdersFilter.tsx
+++ b/source/modules/commerce/components/OrdersFilter.tsx
@@ -11,10 +11,6 @@ import { InputSelect } from '@structure/source/common/forms/InputSelect';
 // Dependencies - API
 import { CommerceOrderStatus } from '@structure/source/api/graphql/GraphQlGeneratedCode';
 
-// Dependencies - Assets
-import SearchIcon from '@structure/assets/icons/navigation/SearchIcon.svg';
-import FilterIcon from '@structure/assets/icons/interface/FilterIcon.svg';
-
 // Interface - OrdersFilterInterface
 export interface OrdersFilterInterface {
     emailAddress?: string;
@@ -48,10 +44,10 @@ export function OrdersFilter(properties: OrdersFilterProperties) {
     // Generate status options from enum
     const statusOptions = [
         { value: 'all', content: 'All Statuses' },
-        ...Object.values(CommerceOrderStatus).map(status => ({
+        ...Object.values(CommerceOrderStatus).map((status) => ({
             value: status,
-            content: status
-        }))
+            content: status,
+        })),
     ];
 
     // Render the component
@@ -70,11 +66,11 @@ export function OrdersFilter(properties: OrdersFilterProperties) {
                             setEmailAddress(value || '');
                         }}
                         onKeyDown={function (event) {
-                            if (event.key === 'Enter') {
+                            if(event.key === 'Enter') {
                                 handleApplyFilters();
                             }
                         }}
-                        variant='search'
+                        variant="search"
                     />
                 </div>
 

--- a/source/modules/commerce/pages/ops/OrdersPage.tsx
+++ b/source/modules/commerce/pages/ops/OrdersPage.tsx
@@ -52,6 +52,15 @@ export function OrdersPage() {
         return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
     }
 
+    type OrderItem = NonNullable<typeof commerceOrdersPrivilegedRequest.data>['commerceOrdersPrivileged']['items'][number];
+
+    function getFullName(order: OrderItem): string {
+        const firstName = order.shippingInfo?.shippingAddress?.firstName || '';
+        const lastName = order.shippingInfo?.shippingAddress?.lastName || '';
+        const fullName = `${firstName} ${lastName}`.trim();
+        return fullName || 'N/A';
+    }
+
     // Render the component
     return (
         <div className="px-6 py-4">
@@ -67,16 +76,18 @@ export function OrdersPage() {
                         {[...Array(itemsPerPage)].map((_, index) => (
                             <div
                                 key={index}
-                                className="grid grid-cols-[1fr] items-center gap-3 py-2 md:grid-cols-[200px_200px_120px_120px]"
+                                className="grid grid-cols-[1fr] items-center gap-3 py-2 md:grid-cols-[200px_200px_200px_120px_120px]"
                             >
                                 {/* Mobile: Stacked Info Placeholders */}
                                 <div className="flex flex-col space-y-2 md:hidden">
                                     <PlaceholderAnimation className="h-5 w-40" />
                                     <PlaceholderAnimation className="h-3.5 w-40" />
                                     <PlaceholderAnimation className="h-3.5 w-40" />
+                                    <PlaceholderAnimation className="h-3.5 w-40" />
                                 </div>
 
                                 {/* Desktop: Column Info Placeholders */}
+                                <PlaceholderAnimation className="hidden h-5 w-40 md:block" />
                                 <PlaceholderAnimation className="hidden h-5 w-40 md:block" />
                                 <PlaceholderAnimation className="hidden h-5 w-40 md:block" />
                                 <PlaceholderAnimation className="hidden h-5 w-40 md:block" />
@@ -93,8 +104,9 @@ export function OrdersPage() {
                 {commerceOrdersPrivilegedRequest.data?.commerceOrdersPrivileged.items && (
                     <>
                         {/* Header Row */}
-                        <div className="hidden grid-cols-[200px_200px_120px_120px] items-center gap-3 py-2 font-medium md:grid">
+                        <div className="hidden grid-cols-[200px_200px_200px_120px_120px] items-center gap-3 py-2 font-medium md:grid">
                             <div>Order ID</div>
+                            <div>Name</div>
                             <div>Email</div>
                             <div>Status</div>
                             <div>Amount</div>
@@ -103,11 +115,12 @@ export function OrdersPage() {
                         {commerceOrdersPrivilegedRequest.data.commerceOrdersPrivileged.items.map((order) => (
                             <div
                                 key={order.id}
-                                className="grid grid-cols-[1fr] items-center gap-3 py-2 md:grid-cols-[200px_200px_120px_120px_400px]"
+                                className="grid grid-cols-[1fr] items-center gap-3 py-2 md:grid-cols-[200px_200px_200px_120px_120px_400px]"
                             >
                                 {/* Mobile View */}
                                 <div className="md:hidden">
                                     <div className="font-medium">{order.identifier}</div>
+                                    <div className="neutral text-sm">{getFullName(order)}</div>
                                     <div className="neutral text-sm">{order.emailAddress}</div>
                                     <div className="neutral text-sm">{order.status}</div>
                                     <div className="neutral text-sm">
@@ -125,6 +138,7 @@ export function OrdersPage() {
                                         {order.identifier}
                                     </Link>
                                 </div>
+                                <div className="neutral hidden truncate md:block">{getFullName(order)}</div>
                                 <div className="neutral hidden truncate md:block">{order.emailAddress}</div>
                                 <div className="neutral hidden truncate md:block">{order.status}</div>
                                 <div className="neutral hidden truncate md:block">


### PR DESCRIPTION
[Requests from Natalie](https://discord.com/channels/1082851919208402976/1353125212773683253/1417201868391845939):

- Added "Name" column to table
- Add search by email address or status (there's a lot of fields so I didn't try to use the more generic filter component) to top of /ops/orders page

<img width="1370" height="365" alt="Screenshot 2025-09-15 at 12 59 41 PM" src="https://github.com/user-attachments/assets/05ac623d-99d8-411f-8017-f186279fc3c6" />

This doesn't include the recurring order details since it's not immediately available from CommerceOrder.
Curious what your thoughts are about copying OrderPage into /app repo instead so that we can reference Stack/non-generic details.