### PR TITLE
[Auth] Add AccountMaintenanceDialog

### DIFF
--- a/source/api/graphql/generated/gql.ts
+++ b/source/api/graphql/generated/gql.ts
@@ -14,6 +14,7 @@ import * as types from './graphql';
  */
 type Documents = {
     'query NoOp { __typename }': typeof types.NoOpDocument;
+    '\n            query AccountMaintenanceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ': typeof types.AccountMaintenanceAuthenticationDocument;
     '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ': typeof types.AccountMaintenanceSessionCreateDocument;
     '\n            query AccountMaintenenceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ': typeof types.AccountMaintenenceAuthenticationDocument;
     '\n            query AccountAccessRolesPrivileged {\n                accountAccessRolesPrivileged {\n                    type\n                    description\n                }\n            }\n        ': typeof types.AccountAccessRolesPrivilegedDocument;
@@ -71,6 +72,8 @@ type Documents = {
 };
 const documents: Documents = {
     'query NoOp { __typename }': types.NoOpDocument,
+    '\n            query AccountMaintenanceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ':
+        types.AccountMaintenanceAuthenticationDocument,
     '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ':
         types.AccountMaintenanceSessionCreateDocument,
     '\n            query AccountMaintenenceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ':
@@ -185,6 +188,12 @@ const documents: Documents = {
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: 'query NoOp { __typename }'): typeof import('./graphql').NoOpDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+    source: '\n            query AccountMaintenanceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ',
+): typeof import('./graphql').AccountMaintenanceAuthenticationDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/source/api/graphql/generated/gql.ts
+++ b/source/api/graphql/generated/gql.ts
@@ -14,6 +14,8 @@ import * as types from './graphql';
  */
 type Documents = {
     'query NoOp { __typename }': typeof types.NoOpDocument;
+    '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ': typeof types.AccountMaintenanceSessionCreateDocument;
+    '\n            query AccountMaintenenceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ': typeof types.AccountMaintenenceAuthenticationDocument;
     '\n            query AccountAccessRolesPrivileged {\n                accountAccessRolesPrivileged {\n                    type\n                    description\n                }\n            }\n        ': typeof types.AccountAccessRolesPrivilegedDocument;
     '\n            query AccountPrivileged($input: AccountInput!) {\n                accountPrivileged(input: $input) {\n                    profiles {\n                        username\n                        displayName\n                        images {\n                            url\n                            variant\n                        }\n                    }\n                }\n            }\n        ': typeof types.AccountPrivilegedDocument;
     '\n            mutation AccountAccessRoleAssignmentCreatePrivileged($input: AccessRoleAssignmentCreateInput!) {\n                accountAccessRoleAssignmentCreatePrivileged(input: $input) {\n                    id\n                    accessRole {\n                        id\n                        type\n                        description\n                    }\n                    status\n                    profile {\n                        username\n                        displayName\n                        images {\n                            url\n                            variant\n                        }\n                        createdAt\n                    }\n                    expiresAt\n                    createdAt\n                    updatedAt\n                }\n            }\n        ': typeof types.AccountAccessRoleAssignmentCreatePrivilegedDocument;
@@ -35,7 +37,6 @@ type Documents = {
     '\n            mutation AccountProfileUpdate($input: AccountProfileUpdateInput!) {\n                accountProfileUpdate(input: $input) {\n                    username\n                    displayName\n                    givenName\n                    familyName\n                    images {\n                        url\n                        variant\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ': typeof types.AccountProfileUpdateDocument;
     '\n                                query AccountProfileUsernameValidate($username: String!) {\n                                    accountProfileUsernameValidate(username: $username)\n                                }\n                            ': typeof types.AccountProfileUsernameValidateDocument;
     '\n            query AccountEnrolledChallenges {\n                account {\n                    enrolledChallenges\n                }\n            }\n        ': typeof types.AccountEnrolledChallengesDocument;
-    '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ': typeof types.AccountMaintenanceSessionCreateDocument;
     '\n            mutation AccountPasswordUpdate($input: AccountPasswordUpdateInput!) {\n                accountPasswordUpdate(input: $input) {\n                    success\n                }\n            }\n        ': typeof types.AccountPasswordUpdateDocument;
     '\n            mutation AccountDelete($reason: String) {\n                accountDelete(reason: $reason) {\n                    success\n                }\n            }\n        ': typeof types.AccountDeleteDocument;
     '\n            query AccountProfilePublic($username: String!) {\n                accountProfilePublic(username: $username) {\n                    username\n                    displayName\n                    images {\n                        url\n                        variant\n                    }\n                    createdAt\n                }\n            }\n        ': typeof types.AccountProfilePublicDocument;
@@ -70,6 +71,10 @@ type Documents = {
 };
 const documents: Documents = {
     'query NoOp { __typename }': types.NoOpDocument,
+    '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ':
+        types.AccountMaintenanceSessionCreateDocument,
+    '\n            query AccountMaintenenceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ':
+        types.AccountMaintenenceAuthenticationDocument,
     '\n            query AccountAccessRolesPrivileged {\n                accountAccessRolesPrivileged {\n                    type\n                    description\n                }\n            }\n        ':
         types.AccountAccessRolesPrivilegedDocument,
     '\n            query AccountPrivileged($input: AccountInput!) {\n                accountPrivileged(input: $input) {\n                    profiles {\n                        username\n                        displayName\n                        images {\n                            url\n                            variant\n                        }\n                    }\n                }\n            }\n        ':
@@ -112,8 +117,6 @@ const documents: Documents = {
         types.AccountProfileUsernameValidateDocument,
     '\n            query AccountEnrolledChallenges {\n                account {\n                    enrolledChallenges\n                }\n            }\n        ':
         types.AccountEnrolledChallengesDocument,
-    '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ':
-        types.AccountMaintenanceSessionCreateDocument,
     '\n            mutation AccountPasswordUpdate($input: AccountPasswordUpdateInput!) {\n                accountPasswordUpdate(input: $input) {\n                    success\n                }\n            }\n        ':
         types.AccountPasswordUpdateDocument,
     '\n            mutation AccountDelete($reason: String) {\n                accountDelete(reason: $reason) {\n                    success\n                }\n            }\n        ':
@@ -182,6 +185,18 @@ const documents: Documents = {
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: 'query NoOp { __typename }'): typeof import('./graphql').NoOpDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+    source: '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ',
+): typeof import('./graphql').AccountMaintenanceSessionCreateDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+    source: '\n            query AccountMaintenenceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ',
+): typeof import('./graphql').AccountMaintenenceAuthenticationDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -308,12 +323,6 @@ export function graphql(
 export function graphql(
     source: '\n            query AccountEnrolledChallenges {\n                account {\n                    enrolledChallenges\n                }\n            }\n        ',
 ): typeof import('./graphql').AccountEnrolledChallengesDocument;
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
-    source: '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ',
-): typeof import('./graphql').AccountMaintenanceSessionCreateDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/source/api/graphql/generated/gql.ts
+++ b/source/api/graphql/generated/gql.ts
@@ -14,7 +14,7 @@ import * as types from './graphql';
  */
 type Documents = {
     'query NoOp { __typename }': typeof types.NoOpDocument;
-    '\n            query AccountMaintenanceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ': typeof types.AccountMaintenanceAuthenticationDocument;
+    '\n            query AccountMaintenanceDialogAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ': typeof types.AccountMaintenanceDialogAuthenticationDocument;
     '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ': typeof types.AccountMaintenanceSessionCreateDocument;
     '\n            query AccountMaintenenceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ': typeof types.AccountMaintenenceAuthenticationDocument;
     '\n            query AccountAccessRolesPrivileged {\n                accountAccessRolesPrivileged {\n                    type\n                    description\n                }\n            }\n        ': typeof types.AccountAccessRolesPrivilegedDocument;
@@ -72,8 +72,8 @@ type Documents = {
 };
 const documents: Documents = {
     'query NoOp { __typename }': types.NoOpDocument,
-    '\n            query AccountMaintenanceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ':
-        types.AccountMaintenanceAuthenticationDocument,
+    '\n            query AccountMaintenanceDialogAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ':
+        types.AccountMaintenanceDialogAuthenticationDocument,
     '\n            mutation AccountMaintenanceSessionCreate {\n                accountMaintenanceSessionCreate {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                    updatedAt\n                    createdAt\n                }\n            }\n        ':
         types.AccountMaintenanceSessionCreateDocument,
     '\n            query AccountMaintenenceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ':
@@ -192,8 +192,8 @@ export function graphql(source: 'query NoOp { __typename }'): typeof import('./g
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-    source: '\n            query AccountMaintenanceAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ',
-): typeof import('./graphql').AccountMaintenanceAuthenticationDocument;
+    source: '\n            query AccountMaintenanceDialogAuthentication {\n                accountAuthentication {\n                    status\n                    scopeType\n                    currentChallenge {\n                        challengeType\n                        status\n                    }\n                }\n            }\n        ',
+): typeof import('./graphql').AccountMaintenanceDialogAuthenticationDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/source/api/graphql/generated/graphql.ts
+++ b/source/api/graphql/generated/graphql.ts
@@ -3844,6 +3844,22 @@ export type NoOpQueryVariables = Exact<{ [key: string]: never }>;
 
 export type NoOpQuery = { __typename: 'Query' };
 
+export type AccountMaintenanceAuthenticationQueryVariables = Exact<{ [key: string]: never }>;
+
+export type AccountMaintenanceAuthenticationQuery = {
+    __typename?: 'Query';
+    accountAuthentication?: {
+        __typename?: 'AuthenticationSession';
+        status: AuthenticationSessionStatus;
+        scopeType: string;
+        currentChallenge?: {
+            __typename?: 'AuthenticationChallenge';
+            challengeType: string;
+            status: AuthenticationChallengeStatus;
+        } | null;
+    } | null;
+};
+
 export type AccountMaintenanceSessionCreateMutationVariables = Exact<{ [key: string]: never }>;
 
 export type AccountMaintenanceSessionCreateMutation = {
@@ -5004,6 +5020,21 @@ export const NoOpDocument = new TypedDocumentString(`
   __typename
 }
     `) as unknown as TypedDocumentString<NoOpQuery, NoOpQueryVariables>;
+export const AccountMaintenanceAuthenticationDocument = new TypedDocumentString(`
+    query AccountMaintenanceAuthentication {
+  accountAuthentication {
+    status
+    scopeType
+    currentChallenge {
+      challengeType
+      status
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<
+    AccountMaintenanceAuthenticationQuery,
+    AccountMaintenanceAuthenticationQueryVariables
+>;
 export const AccountMaintenanceSessionCreateDocument = new TypedDocumentString(`
     mutation AccountMaintenanceSessionCreate {
   accountMaintenanceSessionCreate {

--- a/source/api/graphql/generated/graphql.ts
+++ b/source/api/graphql/generated/graphql.ts
@@ -3844,6 +3844,40 @@ export type NoOpQueryVariables = Exact<{ [key: string]: never }>;
 
 export type NoOpQuery = { __typename: 'Query' };
 
+export type AccountMaintenanceSessionCreateMutationVariables = Exact<{ [key: string]: never }>;
+
+export type AccountMaintenanceSessionCreateMutation = {
+    __typename?: 'Mutation';
+    accountMaintenanceSessionCreate: {
+        __typename?: 'AuthenticationSession';
+        status: AuthenticationSessionStatus;
+        scopeType: string;
+        updatedAt: any;
+        createdAt: any;
+        currentChallenge?: {
+            __typename?: 'AuthenticationChallenge';
+            challengeType: string;
+            status: AuthenticationChallengeStatus;
+        } | null;
+    };
+};
+
+export type AccountMaintenenceAuthenticationQueryVariables = Exact<{ [key: string]: never }>;
+
+export type AccountMaintenenceAuthenticationQuery = {
+    __typename?: 'Query';
+    accountAuthentication?: {
+        __typename?: 'AuthenticationSession';
+        status: AuthenticationSessionStatus;
+        scopeType: string;
+        currentChallenge?: {
+            __typename?: 'AuthenticationChallenge';
+            challengeType: string;
+            status: AuthenticationChallengeStatus;
+        } | null;
+    } | null;
+};
+
 export type AccountAccessRolesPrivilegedQueryVariables = Exact<{ [key: string]: never }>;
 
 export type AccountAccessRolesPrivilegedQuery = {
@@ -4228,24 +4262,6 @@ export type AccountEnrolledChallengesQueryVariables = Exact<{ [key: string]: nev
 export type AccountEnrolledChallengesQuery = {
     __typename?: 'Query';
     account: { __typename?: 'Account'; enrolledChallenges: Array<string> };
-};
-
-export type AccountMaintenanceSessionCreateMutationVariables = Exact<{ [key: string]: never }>;
-
-export type AccountMaintenanceSessionCreateMutation = {
-    __typename?: 'Mutation';
-    accountMaintenanceSessionCreate: {
-        __typename?: 'AuthenticationSession';
-        status: AuthenticationSessionStatus;
-        scopeType: string;
-        updatedAt: any;
-        createdAt: any;
-        currentChallenge?: {
-            __typename?: 'AuthenticationChallenge';
-            challengeType: string;
-            status: AuthenticationChallengeStatus;
-        } | null;
-    };
 };
 
 export type AccountPasswordUpdateMutationVariables = Exact<{
@@ -4988,6 +5004,38 @@ export const NoOpDocument = new TypedDocumentString(`
   __typename
 }
     `) as unknown as TypedDocumentString<NoOpQuery, NoOpQueryVariables>;
+export const AccountMaintenanceSessionCreateDocument = new TypedDocumentString(`
+    mutation AccountMaintenanceSessionCreate {
+  accountMaintenanceSessionCreate {
+    status
+    scopeType
+    currentChallenge {
+      challengeType
+      status
+    }
+    updatedAt
+    createdAt
+  }
+}
+    `) as unknown as TypedDocumentString<
+    AccountMaintenanceSessionCreateMutation,
+    AccountMaintenanceSessionCreateMutationVariables
+>;
+export const AccountMaintenenceAuthenticationDocument = new TypedDocumentString(`
+    query AccountMaintenenceAuthentication {
+  accountAuthentication {
+    status
+    scopeType
+    currentChallenge {
+      challengeType
+      status
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<
+    AccountMaintenenceAuthenticationQuery,
+    AccountMaintenenceAuthenticationQueryVariables
+>;
 export const AccountAccessRolesPrivilegedDocument = new TypedDocumentString(`
     query AccountAccessRolesPrivileged {
   accountAccessRolesPrivileged {
@@ -5339,23 +5387,6 @@ export const AccountEnrolledChallengesDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<AccountEnrolledChallengesQuery, AccountEnrolledChallengesQueryVariables>;
-export const AccountMaintenanceSessionCreateDocument = new TypedDocumentString(`
-    mutation AccountMaintenanceSessionCreate {
-  accountMaintenanceSessionCreate {
-    status
-    scopeType
-    currentChallenge {
-      challengeType
-      status
-    }
-    updatedAt
-    createdAt
-  }
-}
-    `) as unknown as TypedDocumentString<
-    AccountMaintenanceSessionCreateMutation,
-    AccountMaintenanceSessionCreateMutationVariables
->;
 export const AccountPasswordUpdateDocument = new TypedDocumentString(`
     mutation AccountPasswordUpdate($input: AccountPasswordUpdateInput!) {
   accountPasswordUpdate(input: $input) {

--- a/source/api/graphql/generated/graphql.ts
+++ b/source/api/graphql/generated/graphql.ts
@@ -3844,9 +3844,9 @@ export type NoOpQueryVariables = Exact<{ [key: string]: never }>;
 
 export type NoOpQuery = { __typename: 'Query' };
 
-export type AccountMaintenanceAuthenticationQueryVariables = Exact<{ [key: string]: never }>;
+export type AccountMaintenanceDialogAuthenticationQueryVariables = Exact<{ [key: string]: never }>;
 
-export type AccountMaintenanceAuthenticationQuery = {
+export type AccountMaintenanceDialogAuthenticationQuery = {
     __typename?: 'Query';
     accountAuthentication?: {
         __typename?: 'AuthenticationSession';
@@ -5020,8 +5020,8 @@ export const NoOpDocument = new TypedDocumentString(`
   __typename
 }
     `) as unknown as TypedDocumentString<NoOpQuery, NoOpQueryVariables>;
-export const AccountMaintenanceAuthenticationDocument = new TypedDocumentString(`
-    query AccountMaintenanceAuthentication {
+export const AccountMaintenanceDialogAuthenticationDocument = new TypedDocumentString(`
+    query AccountMaintenanceDialogAuthentication {
   accountAuthentication {
     status
     scopeType
@@ -5032,8 +5032,8 @@ export const AccountMaintenanceAuthenticationDocument = new TypedDocumentString(
   }
 }
     `) as unknown as TypedDocumentString<
-    AccountMaintenanceAuthenticationQuery,
-    AccountMaintenanceAuthenticationQueryVariables
+    AccountMaintenanceDialogAuthenticationQuery,
+    AccountMaintenanceDialogAuthenticationQueryVariables
 >;
 export const AccountMaintenanceSessionCreateDocument = new TypedDocumentString(`
     mutation AccountMaintenanceSessionCreate {

--- a/source/modules/account/components/AccountMaintenanceDialog.tsx
+++ b/source/modules/account/components/AccountMaintenanceDialog.tsx
@@ -143,21 +143,26 @@ export function AccountMaintenanceDialog(properties: AccountMaintenanceDialogPro
         // Show the authentication form only if not checking and not authenticated
         content = (
             <div className="p-6">
-                <AccountMaintenanceSession
-                    title="Verify Identity"
-                    description={`To ${properties.actionText}, please verify your identity for security purposes.`}
-                    buttonText="Continue"
-                    onAuthenticated={properties.onAuthenticated}
-                >
-                    {/* This will be shown after authentication completes */}
-                    <div className="text-center">
-                        <div className="mb-4 flex justify-center">
-                            <LoadingAnimation className="h-12 w-12" />
+                {shouldProceedRef.current ? (
+                    <AccountMaintenanceSession
+                        title="Verify Identity"
+                        description={`To ${properties.actionText}, please verify your identity for security purposes.`}
+                        buttonText="Continue"
+                        onAuthenticated={properties.onAuthenticated}
+                    >
+                        {/* This will be shown after authentication completes */}
+                        <div className="text-center">
+                            <div className="mb-4 flex justify-center">
+                                <LoadingAnimation className="h-12 w-12" />
+                            </div>
+                            <h2 className="mb-2 text-lg font-semibold">Authentication Successful</h2>
+                            <p className="text-sm text-foreground-secondary">Processing your request...</p>
                         </div>
-                        <h2 className="mb-2 text-lg font-semibold">Authentication Successful</h2>
-                        <p className="text-sm text-foreground-secondary">Processing your request...</p>
-                    </div>
-                </AccountMaintenanceSession>
+                    </AccountMaintenanceSession>
+                ) : (
+                    // Dialog is closing, show empty content to prevent flash
+                    <div />
+                )}
             </div>
         );
     }

--- a/source/modules/account/components/AccountMaintenanceDialog.tsx
+++ b/source/modules/account/components/AccountMaintenanceDialog.tsx
@@ -1,0 +1,156 @@
+'use client'; // This component uses client-only features
+
+// Dependencies - React
+import React from 'react';
+
+// Dependencies - Main Components
+import { DialogProperties, Dialog } from '@structure/source/common/dialogs/Dialog';
+import { AccountMaintenanceSession } from '@structure/source/modules/account/components/AccountMaintenanceSession';
+import { LoadingAnimation } from '@structure/source/common/animations/LoadingAnimation';
+
+// Dependencies - API
+import { networkService, gql } from '@structure/source/services/network/NetworkService';
+import { AuthenticationSessionStatus } from '@structure/source/api/graphql/GraphQlGeneratedCode';
+
+// Component - AccountMaintenanceDialog
+export interface AccountMaintenanceDialogProperties extends DialogProperties {
+    actionText: string;
+    onAuthenticated: () => void;
+}
+
+export function AccountMaintenanceDialog(properties: AccountMaintenanceDialogProperties) {
+    // State
+    const [open, setOpen] = React.useState(properties.open ?? false);
+    const [checkingAuth, setCheckingAuth] = React.useState(false);
+    const [isAuthenticated, setIsAuthenticated] = React.useState(false);
+    const [hasCheckedAuth, setHasCheckedAuth] = React.useState(false);
+
+    // Check current authentication session - using mutation to get fresh data
+    const accountAuthenticationCheck = networkService.useGraphQlMutation(
+        gql(`
+            query AccountAuthentication {
+                accountAuthentication {
+                    status
+                    scopeType
+                    currentChallenge {
+                        challengeType
+                        status
+                    }
+                }
+            }
+        `)
+    );
+
+    // Effect to handle dialog opening and closing
+    React.useEffect(
+        function () {
+            setOpen(properties.open ?? false);
+
+            // Reset state when dialog closes
+            if(!properties.open) {
+                setCheckingAuth(false);
+                setIsAuthenticated(false);
+                setHasCheckedAuth(false);
+            }
+        },
+        [properties.open],
+    );
+
+    // Effect to check authentication when dialog opens
+    React.useEffect(
+        function () {
+            // Only check auth if dialog is open and we haven't checked yet
+            if(open && !hasCheckedAuth && !checkingAuth) {
+                setCheckingAuth(true);
+                setHasCheckedAuth(true);
+
+                // Execute the authentication check
+                accountAuthenticationCheck.execute().then(function(result) {
+                    const authData = result?.accountAuthentication;
+                    if(
+                        authData?.status === AuthenticationSessionStatus.Authenticated &&
+                        authData?.scopeType === 'AccountMaintenance'
+                    ) {
+                        // Already authenticated
+                        setIsAuthenticated(true);
+                        // Small delay to show the success state
+                        setTimeout(function () {
+                            properties.onAuthenticated();
+                            setOpen(false);
+                            properties.onOpenChange?.(false);
+                        }, 500);
+                    }
+                    // Always stop checking auth after we've checked
+                    setCheckingAuth(false);
+                }).catch(function(error) {
+                    console.error('Failed to check authentication:', error);
+                    setCheckingAuth(false);
+                });
+            }
+        },
+        [open, hasCheckedAuth, checkingAuth],
+    );
+
+    // Function to intercept the onOpenChange event
+    function onOpenChangeIntercept(open: boolean) {
+        // Optionally call the onOpenChange callback
+        properties.onOpenChange?.(open);
+
+        // Update the open state
+        setOpen(open);
+    }
+
+    // Render the component
+    let content;
+
+    if(checkingAuth || isAuthenticated) {
+        // Show loading state while checking authentication or when already authenticated (before closing)
+        content = (
+            <div className="p-6 text-center">
+                <div className="mb-4 flex justify-center">
+                    <LoadingAnimation className="h-12 w-12" />
+                </div>
+                <h2 className="mb-2 text-lg font-semibold">Verifying Identity</h2>
+                <p className="text-sm text-foreground-secondary">
+                    {isAuthenticated
+                        ? 'Identity verified. Processing your request...'
+                        : 'Checking authentication status...'}
+                </p>
+            </div>
+        );
+    }
+    else {
+        // Show the authentication form only if not checking and not authenticated
+        content = (
+            <div className="p-6">
+                <AccountMaintenanceSession
+                    title="Verify Identity"
+                    description={`To ${properties.actionText}, please verify your identity for security purposes.`}
+                    buttonText="Continue"
+                    onAuthenticated={properties.onAuthenticated}
+                >
+                    {/* This will be shown after authentication completes */}
+                    <div className="text-center">
+                        <div className="mb-4 flex justify-center">
+                            <LoadingAnimation className="h-12 w-12" />
+                        </div>
+                        <h2 className="mb-2 text-lg font-semibold">Authentication Successful</h2>
+                        <p className="text-sm text-foreground-secondary">Processing your request...</p>
+                    </div>
+                </AccountMaintenanceSession>
+            </div>
+        );
+    }
+
+    return (
+        <Dialog
+            className="max-w-md"
+            accessibilityTitle="Verify Identity"
+            content={content}
+            {...properties}
+            // Spread these properties after all properties to ensure they are not overwritten
+            open={open}
+            onOpenChange={onOpenChangeIntercept}
+        />
+    );
+}

--- a/source/modules/account/components/AccountMaintenanceSession.tsx
+++ b/source/modules/account/components/AccountMaintenanceSession.tsx
@@ -1,0 +1,206 @@
+'use client'; // This component uses client-only features
+
+// Dependencies - React
+import React from 'react';
+
+// Dependencies - Main Components
+import { Button } from '@structure/source/common/buttons/Button';
+import { EmailVerificationChallenge } from '@structure/source/modules/account/pages/authentication/components/challenges/email-verification/EmailVerificationChallenge';
+import { AccountPasswordChallenge } from '@structure/source/modules/account/pages/authentication/components/challenges/account-password/AccountPasswordChallenge';
+
+// Dependencies - Account
+import { useAccount } from '@structure/source/modules/account/providers/AccountProvider';
+
+// Dependencies - API
+import { networkService, gql } from '@structure/source/services/network/NetworkService';
+import {
+    AccountAuthenticationQuery,
+    AuthenticationSessionStatus,
+} from '@structure/source/api/graphql/GraphQlGeneratedCode';
+
+// Component - AccountMaintenanceSession
+export interface AccountMaintenanceSessionProperties {
+    title: string;
+    description: string;
+    buttonText?: string;
+    children: React.ReactNode;
+    onAuthenticated?: () => void;
+}
+
+export function AccountMaintenanceSession(properties: AccountMaintenanceSessionProperties) {
+    // State
+    const [authenticationSession, setAuthenticationSession] = React.useState<
+        AccountAuthenticationQuery['accountAuthentication'] | undefined
+    >(undefined);
+    const [isAuthenticated, setIsAuthenticated] = React.useState(false);
+
+    // Hooks
+    const account = useAccount();
+    const emailAddress = account.data?.emailAddress ?? '';
+
+    // Hooks - API - Mutations
+    const accountMaintenanceSessionCreateRequest = networkService.useGraphQlMutation(
+        gql(`
+            mutation AccountMaintenanceSessionCreate {
+                accountMaintenanceSessionCreate {
+                    status
+                    scopeType
+                    currentChallenge {
+                        challengeType
+                        status
+                    }
+                    updatedAt
+                    createdAt
+                }
+            }
+        `),
+    );
+
+    // Function to create the account maintenance session
+    async function createAccountMaintenanceSession() {
+        await accountMaintenanceSessionCreateRequest.execute();
+
+        // Check if immediately authenticated (no challenges required)
+        if(
+            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.status ===
+                AuthenticationSessionStatus.Authenticated &&
+            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.scopeType ===
+                'AccountMaintenance'
+        ) {
+            setIsAuthenticated(true);
+            properties.onAuthenticated?.();
+        }
+    }
+
+    // Effect to handle authentication state changes
+    React.useEffect(
+        function () {
+            if(
+                authenticationSession?.status === AuthenticationSessionStatus.Authenticated &&
+                authenticationSession?.scopeType === 'AccountMaintenance'
+            ) {
+                setIsAuthenticated(true);
+                properties.onAuthenticated?.();
+            }
+        },
+        [authenticationSession, properties],
+    );
+
+    // The current authentication component based on the authentication state
+    let currentAuthenticationComponent = null;
+
+    // Authenticated - show the protected content
+    if(
+        isAuthenticated ||
+        // The account maintenance session shows we are authenticated and the scope is AccountMaintenance
+        (accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.status ==
+            AuthenticationSessionStatus.Authenticated &&
+            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.scopeType ==
+                'AccountMaintenance') ||
+        // Or, the current authentication session shows we are authenticated and the scope is AccountMaintenance
+        (authenticationSession?.status == AuthenticationSessionStatus.Authenticated &&
+            authenticationSession?.scopeType == 'AccountMaintenance')
+    ) {
+        currentAuthenticationComponent = <>{properties.children}</>;
+    }
+    // Challenged - show the appropriate challenge
+    else if(
+        accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.status ==
+        AuthenticationSessionStatus.Challenged
+    ) {
+        // Challenge - Email Verification
+        if(
+            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.currentChallenge
+                ?.challengeType == 'EmailVerification'
+        ) {
+            currentAuthenticationComponent = (
+                <EmailVerificationChallenge
+                    emailAddress={emailAddress}
+                    onSuccess={function (authenticationSession) {
+                        setAuthenticationSession(authenticationSession);
+                    }}
+                />
+            );
+        }
+        // Challenge - Account Password
+        else if(
+            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.currentChallenge
+                ?.challengeType == 'AccountPassword'
+        ) {
+            currentAuthenticationComponent = (
+                <AccountPasswordChallenge
+                    emailAddress={emailAddress}
+                    onSuccess={function (authenticationSession) {
+                        setAuthenticationSession(authenticationSession);
+                    }}
+                />
+            );
+        }
+    }
+    // Ready to start an authentication session
+    else {
+        currentAuthenticationComponent = (
+            <div>
+                <h2 className="text-base font-medium">{properties.title}</h2>
+                <p className="mt-4 text-sm">{properties.description}</p>
+                <Button
+                    loading={accountMaintenanceSessionCreateRequest.isLoading}
+                    className="mt-6"
+                    onClick={function () {
+                        createAccountMaintenanceSession();
+                    }}
+                >
+                    {properties.buttonText || 'Continue'}
+                </Button>
+            </div>
+        );
+    }
+
+    // Render the component
+    return <div>{currentAuthenticationComponent}</div>;
+}
+
+// Hook to check if user is in an authenticated maintenance session
+export function useAccountMaintenanceSession() {
+    const [isAuthenticated, setIsAuthenticated] = React.useState(false);
+    const [isLoading, setIsLoading] = React.useState(false);
+
+    // Hooks - API - Queries
+    const accountAuthenticationQuery = networkService.useGraphQlQuery(
+        gql(`
+            query AccountMaintenenceAuthentication {
+                accountAuthentication {
+                    status
+                    scopeType
+                    currentChallenge {
+                        challengeType
+                        status
+                    }
+                }
+            }
+        `),
+    );
+
+    React.useEffect(
+        function () {
+            if(
+                accountAuthenticationQuery.data?.accountAuthentication?.status ===
+                    AuthenticationSessionStatus.Authenticated &&
+                accountAuthenticationQuery.data?.accountAuthentication?.scopeType === 'AccountMaintenance'
+            ) {
+                setIsAuthenticated(true);
+            }
+            else {
+                setIsAuthenticated(false);
+            }
+            setIsLoading(accountAuthenticationQuery.isLoading);
+        },
+        [accountAuthenticationQuery.data, accountAuthenticationQuery.isLoading],
+    );
+
+    return {
+        isAuthenticated,
+        isLoading,
+        refresh: accountAuthenticationQuery.refresh,
+    };
+}

--- a/source/modules/account/pages/profile/security/SecurityPage.tsx
+++ b/source/modules/account/pages/profile/security/SecurityPage.tsx
@@ -10,6 +10,7 @@ import { ManagePasswordDialog } from '@structure/source/modules/account/pages/pr
 
 // Dependencies - API
 import { networkService, gql } from '@structure/source/services/network/NetworkService';
+import { AccountMaintenanceDialog } from '../../../components/AccountMaintenanceDialog';
 
 // Metadata
 export async function generateMetadata(): Promise<Metadata> {
@@ -21,7 +22,8 @@ export async function generateMetadata(): Promise<Metadata> {
 // Component - SecurityPage
 export function SecurityPage() {
     // State
-    const [managePasswordDialogOpen, setManagePasswordDialogOpen] = React.useState(false);
+    const [needsAuth, setNeedsAuth] = React.useState(false);
+    const [showPasswordForm, setShowPasswordForm] = React.useState(false);
 
     // Hooks - API - Queries
     const accountEnrolledChallengesRequest = networkService.useGraphQlQuery(
@@ -39,6 +41,16 @@ export function SecurityPage() {
         (accountEnrolledChallengesRequest.data?.account.enrolledChallenges.length ?? 0) > 0 &&
         accountEnrolledChallengesRequest.data?.account.enrolledChallenges.includes('AccountPassword');
 
+    // Functions
+    function handlePasswordClick() {
+        setNeedsAuth(true);
+    }
+
+    async function handleAuthenticated() {
+        setNeedsAuth(false);
+        setShowPasswordForm(true);
+    }
+
     // Render the component
     return (
         <>
@@ -46,18 +58,29 @@ export function SecurityPage() {
 
             <div className="mt-10">
                 {/* Set or Change Password Button */}
-                <Button
-                    onClick={function () {
-                        setManagePasswordDialogOpen(true);
-                    }}
-                >
+                <Button onClick={handlePasswordClick}>
                     {accountHasPasswordSet ? 'Change Password' : 'Set Password'}
                 </Button>
             </div>
 
+            {/* Account Maintenance Dialog - Shows when auth is needed */}
+            <AccountMaintenanceDialog
+                open={needsAuth}
+                onOpenChange={function (open) {
+                    if(!open) {
+                        setNeedsAuth(false);
+                    }
+                }}
+                actionText={accountHasPasswordSet ? 'change your password' : 'set your password'}
+                onAuthenticated={handleAuthenticated}
+            />
+
+            {/* Password Management Dialog - Shows after authentication */}
             <ManagePasswordDialog
-                open={managePasswordDialogOpen}
-                onOpenChange={setManagePasswordDialogOpen}
+                open={showPasswordForm}
+                onOpenChange={function (open) {
+                    setShowPasswordForm(open);
+                }}
                 accountHasPasswordSet={accountHasPasswordSet || false}
             />
         </>

--- a/source/modules/account/pages/profile/security/SecurityPage.tsx
+++ b/source/modules/account/pages/profile/security/SecurityPage.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 // Component - SecurityPage
 export function SecurityPage() {
     // State
-    const [needsAuth, setNeedsAuth] = React.useState(false);
+    const [needsAuthentication, setNeedsAuthentication] = React.useState(false);
     const [showPasswordForm, setShowPasswordForm] = React.useState(false);
 
     // Hooks - API - Queries
@@ -43,11 +43,11 @@ export function SecurityPage() {
 
     // Functions
     function handlePasswordClick() {
-        setNeedsAuth(true);
+        setNeedsAuthentication(true);
     }
 
     async function handleAuthenticated() {
-        setNeedsAuth(false);
+        setNeedsAuthentication(false);
         setShowPasswordForm(true);
     }
 
@@ -65,10 +65,10 @@ export function SecurityPage() {
 
             {/* Account Maintenance Dialog - Shows when auth is needed */}
             <AccountMaintenanceDialog
-                open={needsAuth}
+                open={needsAuthentication}
                 onOpenChange={function (open) {
                     if(!open) {
-                        setNeedsAuth(false);
+                        setNeedsAuthentication(false);
                     }
                 }}
                 actionText={accountHasPasswordSet ? 'change your password' : 'set your password'}

--- a/source/modules/account/pages/profile/security/components/ManagePassword.tsx
+++ b/source/modules/account/pages/profile/security/components/ManagePassword.tsx
@@ -4,20 +4,8 @@
 import React from 'react';
 
 // Dependencies - Main Components
-import { Button } from '@structure/source/common/buttons/Button';
-import { EmailVerificationChallenge } from '@structure/source/modules/account/pages/authentication/components/challenges/email-verification/EmailVerificationChallenge';
-import { AccountPasswordChallenge } from '@structure/source/modules/account/pages/authentication/components/challenges/account-password/AccountPasswordChallenge';
+import { AccountMaintenanceSession } from '@structure/source/modules/account/components/AccountMaintenanceSession';
 import { ManagePasswordForm } from '@structure/source/modules/account/pages/profile/security/components/ManagePasswordForm';
-
-// Dependencies - Account
-import { useAccount } from '@structure/source/modules/account/providers/AccountProvider';
-
-// Dependencies - API
-import { networkService, gql } from '@structure/source/services/network/NetworkService';
-import {
-    AccountAuthenticationQuery,
-    AuthenticationSessionStatus,
-} from '@structure/source/api/graphql/GraphQlGeneratedCode';
 
 // Component - ManagePassword
 export interface ManagePasswordProperties {
@@ -25,116 +13,17 @@ export interface ManagePasswordProperties {
     onComplete?: () => void;
 }
 export function ManagePassword(properties: ManagePasswordProperties) {
-    // State
-    const [authenticationSession, setAuthenticationSession] = React.useState<
-        AccountAuthenticationQuery['accountAuthentication'] | undefined
-    >(undefined);
-
-    // Hooks
-    const account = useAccount();
-    const emailAddress = account.data?.emailAddress ?? '';
-
-    // Hooks - API - Mutations
-    const accountMaintenanceSessionCreateRequest = networkService.useGraphQlMutation(
-        gql(`
-            mutation AccountMaintenanceSessionCreate {
-                accountMaintenanceSessionCreate {
-                    status
-                    scopeType
-                    currentChallenge {
-                        challengeType
-                        status
-                    }
-                    updatedAt
-                    createdAt
-                }
-            }
-        `),
-    );
-
-    // Function to create the account maintenance session
-    async function createAccountMaintenanceSession() {
-        await accountMaintenanceSessionCreateRequest.execute();
-    }
-
-    // The current authentication component based on the authentication state
-    let currentAuthenticationComponent = null;
-
-    // Authenticated
-    if(
-        // The account maintenance session shows we are authenticated and the scope is AccountMaintenance
-        (accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.status ==
-            AuthenticationSessionStatus.Authenticated &&
-            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.scopeType ==
-                'AccountMaintenance') ||
-        // Or, the current authentication session shows we are authenticated and the scope is AccountMaintenance
-        (authenticationSession?.status == AuthenticationSessionStatus.Authenticated &&
-            authenticationSession?.scopeType == 'AccountMaintenance')
-    ) {
-        currentAuthenticationComponent = (
+    // Render the component
+    return (
+        <AccountMaintenanceSession
+            title={`${properties.accountHasPasswordSet ? 'Change' : 'Set'} Password`}
+            description={`To ${properties.accountHasPasswordSet ? 'change' : 'set'} your password, please verify your identity.`}
+            buttonText="Continue"
+        >
             <ManagePasswordForm
                 accountHasPasswordSet={properties.accountHasPasswordSet}
                 onComplete={properties.onComplete}
             />
-        );
-    }
-    // Challenged
-    else if(
-        accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.status ==
-        AuthenticationSessionStatus.Challenged
-    ) {
-        // Challenge - Email Verification
-        if(
-            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.currentChallenge
-                ?.challengeType == 'EmailVerification'
-        ) {
-            currentAuthenticationComponent = (
-                <EmailVerificationChallenge
-                    emailAddress={emailAddress}
-                    onSuccess={function (authenticationSession) {
-                        setAuthenticationSession(authenticationSession);
-                    }}
-                />
-            );
-        }
-        // Challenge - Account Password
-        else if(
-            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.currentChallenge
-                ?.challengeType == 'AccountPassword'
-        ) {
-            currentAuthenticationComponent = (
-                <AccountPasswordChallenge
-                    emailAddress={emailAddress}
-                    onSuccess={function (authenticationSession) {
-                        setAuthenticationSession(authenticationSession);
-                    }}
-                />
-            );
-        }
-    }
-    // Ready to start an authentication session
-    else {
-        currentAuthenticationComponent = (
-            <div>
-                <h2 className="text-base font-medium">
-                    {properties.accountHasPasswordSet ? 'Change' : 'Set'} Password
-                </h2>
-                <p className="mt-4 text-sm">
-                    To {properties.accountHasPasswordSet ? 'change' : 'set'} your password, please verify your identity.
-                </p>
-                <Button
-                    loading={accountMaintenanceSessionCreateRequest.isLoading}
-                    className="mt-6"
-                    onClick={function () {
-                        createAccountMaintenanceSession();
-                    }}
-                >
-                    Continue
-                </Button>
-            </div>
-        );
-    }
-
-    // Render the component
-    return <div>{currentAuthenticationComponent}</div>;
+        </AccountMaintenanceSession>
+    );
 }

--- a/source/modules/account/pages/profile/security/components/ManagePasswordDialog.tsx
+++ b/source/modules/account/pages/profile/security/components/ManagePasswordDialog.tsx
@@ -45,6 +45,10 @@ export function ManagePasswordDialog(properties: ManagePasswordDialogProperties)
                     }}
                 />
             }
+            onOpenAutoFocus={function(event) {
+                // Prevent auto-focus which might trigger validation
+                event.preventDefault();
+            }}
             {...properties}
             // Spread these properties after all properties to ensure they are not overwritten
             open={open}

--- a/source/modules/account/pages/profile/security/components/ManagePasswordDialog.tsx
+++ b/source/modules/account/pages/profile/security/components/ManagePasswordDialog.tsx
@@ -22,10 +22,11 @@ export function ManagePasswordDialog(properties: ManagePasswordDialogProperties)
             if(properties.open) {
                 setOpen(true);
                 setShowForm(true);
-            } else {
+            }
+            else {
                 // Hide form immediately, then close dialog after animation
                 setShowForm(false);
-                setTimeout(function() {
+                setTimeout(function () {
                     setOpen(false);
                 }, 0);
             }
@@ -39,11 +40,12 @@ export function ManagePasswordDialog(properties: ManagePasswordDialogProperties)
             // Hide form first
             setShowForm(false);
             // Then notify parent
-            setTimeout(function() {
+            setTimeout(function () {
                 properties.onOpenChange?.(false);
                 setOpen(false);
             }, 0);
-        } else {
+        }
+        else {
             properties.onOpenChange?.(true);
             setOpen(true);
             setShowForm(true);
@@ -63,7 +65,9 @@ export function ManagePasswordDialog(properties: ManagePasswordDialogProperties)
                             onOpenChangeIntercept(false);
                         }}
                     />
-                ) : <div style={{ minHeight: '200px' }} />
+                ) : (
+                    <div style={{ minHeight: '200px' }} />
+                )
             }
             {...properties}
             // Spread these properties after all properties to ensure they are not overwritten

--- a/source/modules/account/pages/profile/security/components/ManagePasswordDialog.tsx
+++ b/source/modules/account/pages/profile/security/components/ManagePasswordDialog.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 // Dependencies - Main Components
 import { DialogProperties, Dialog } from '@structure/source/common/dialogs/Dialog';
-import { ManagePassword } from '@structure/source/modules/account/pages/profile/security/components/ManagePassword';
+import { ManagePasswordForm } from '@structure/source/modules/account/pages/profile/security/components/ManagePasswordForm';
 
 // Component - ManagePasswordDialog
 export interface ManagePasswordDialogProperties extends DialogProperties {
@@ -35,10 +35,10 @@ export function ManagePasswordDialog(properties: ManagePasswordDialogProperties)
     // Render the component
     return (
         <Dialog
-            className="p-12"
-            accessibilityTitle="Manage Password"
+            className="p-6"
+            accessibilityTitle={properties.accountHasPasswordSet ? 'Change Password' : 'Set Password'}
             content={
-                <ManagePassword
+                <ManagePasswordForm
                     accountHasPasswordSet={properties.accountHasPasswordSet}
                     onComplete={function () {
                         onOpenChangeIntercept(false);

--- a/source/modules/account/pages/profile/security/components/ManagePasswordForm.tsx
+++ b/source/modules/account/pages/profile/security/components/ManagePasswordForm.tsx
@@ -83,10 +83,10 @@ export function ManagePasswordForm(properties: ManagePasswordFormProperties) {
 
             {!success && (
                 <>
-                    <h2 className="text-xl font-medium">
+                    <h2 className="text-lg font-semibold">
                         {properties.accountHasPasswordSet ? 'Change' : 'Set'} Password
                     </h2>
-                    <p className="mt-4">
+                    <p className="mt-2 text-sm text-foreground-secondary">
                         {properties.accountHasPasswordSet
                             ? 'Use this form to change your account password.'
                             : 'Improve the security of your account by setting a password.'}

--- a/source/modules/account/pages/profile/security/components/ManagePasswordForm.tsx
+++ b/source/modules/account/pages/profile/security/components/ManagePasswordForm.tsx
@@ -23,6 +23,9 @@ export interface ManagePasswordFormProperties {
     onComplete?: () => void;
 }
 export function ManagePasswordForm(properties: ManagePasswordFormProperties) {
+    // State
+    const [success, setSuccess] = React.useState(false);
+
     // Hooks
     const accountPasswordUpdateRequest = networkService.useGraphQlMutation(
         gql(`
@@ -33,9 +36,6 @@ export function ManagePasswordForm(properties: ManagePasswordFormProperties) {
             }
         `),
     );
-
-    // State
-    const [success, setSuccess] = React.useState(false);
 
     // Function to handle form submission
     async function handleSubmit(formValues: { newPassword?: string }): Promise<FormSubmitResponseInterface> {
@@ -86,7 +86,7 @@ export function ManagePasswordForm(properties: ManagePasswordFormProperties) {
                     <h2 className="text-lg font-semibold">
                         {properties.accountHasPasswordSet ? 'Change' : 'Set'} Password
                     </h2>
-                    <p className="mt-2 text-sm text-foreground-secondary">
+                    <p className="text-foreground-secondary mt-2 text-sm">
                         {properties.accountHasPasswordSet
                             ? 'Use this form to change your account password.'
                             : 'Improve the security of your account by setting a password.'}

--- a/source/modules/account/pages/profile/settings/SettingsPage.tsx
+++ b/source/modules/account/pages/profile/settings/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { Metadata } from 'next';
 // Dependencies - Main Components
 import { Button } from '@structure/source/common/buttons/Button';
 import { DeleteAccountDialog } from '@structure/source/modules/account/pages/profile/settings/components/DeleteAccountDialog';
+import { AccountMaintenanceDialog } from '@structure/source/modules/account/components/AccountMaintenanceDialog';
 
 // Metadata
 export async function generateMetadata(): Promise<Metadata> {
@@ -18,7 +19,18 @@ export async function generateMetadata(): Promise<Metadata> {
 // Component - SettingsPage
 export function SettingsPage() {
     // State
+    const [needsAuth, setNeedsAuth] = React.useState(false);
     const [deleteAccountDialogOpen, setDeleteAccountDialogOpen] = React.useState(false);
+
+    // Functions
+    function handleDeleteClick() {
+        setNeedsAuth(true);
+    }
+
+    async function handleAuthenticated() {
+        setNeedsAuth(false);
+        setDeleteAccountDialogOpen(true);
+    }
 
     // Render the component
     return (
@@ -28,15 +40,29 @@ export function SettingsPage() {
             <div className="mt-10">
                 <Button
                     variant="destructive"
-                    onClick={function () {
-                        setDeleteAccountDialogOpen(true);
-                    }}
+                    onClick={handleDeleteClick}
                 >
                     Delete Account
                 </Button>
             </div>
 
-            <DeleteAccountDialog open={deleteAccountDialogOpen} onOpenChange={setDeleteAccountDialogOpen} />
+            {/* Account Maintenance Dialog - Shows when auth is needed */}
+            <AccountMaintenanceDialog
+                open={needsAuth}
+                onOpenChange={function (open) {
+                    if(!open) {
+                        setNeedsAuth(false);
+                    }
+                }}
+                actionText="delete your account"
+                onAuthenticated={handleAuthenticated}
+            />
+
+            {/* Delete Account Dialog - Shows after authentication */}
+            <DeleteAccountDialog
+                open={deleteAccountDialogOpen}
+                onOpenChange={setDeleteAccountDialogOpen}
+            />
         </>
     );
 }

--- a/source/modules/account/pages/profile/settings/SettingsPage.tsx
+++ b/source/modules/account/pages/profile/settings/SettingsPage.tsx
@@ -19,16 +19,17 @@ export async function generateMetadata(): Promise<Metadata> {
 // Component - SettingsPage
 export function SettingsPage() {
     // State
-    const [needsAuth, setNeedsAuth] = React.useState(false);
+    const [needsAuthentication, setNeedsAuthentication] = React.useState(false);
     const [deleteAccountDialogOpen, setDeleteAccountDialogOpen] = React.useState(false);
 
-    // Functions
+    // Function to handle delete button click
     function handleDeleteClick() {
-        setNeedsAuth(true);
+        setNeedsAuthentication(true);
     }
 
+    // Function to handle successful authentication
     async function handleAuthenticated() {
-        setNeedsAuth(false);
+        setNeedsAuthentication(false);
         setDeleteAccountDialogOpen(true);
     }
 
@@ -38,20 +39,17 @@ export function SettingsPage() {
             <h1>Settings</h1>
 
             <div className="mt-10">
-                <Button
-                    variant="destructive"
-                    onClick={handleDeleteClick}
-                >
+                <Button variant="destructive" onClick={handleDeleteClick}>
                     Delete Account
                 </Button>
             </div>
 
-            {/* Account Maintenance Dialog - Shows when auth is needed */}
+            {/* Account Maintenance Dialog - Shows when authentication is needed */}
             <AccountMaintenanceDialog
-                open={needsAuth}
+                open={needsAuthentication}
                 onOpenChange={function (open) {
                     if(!open) {
-                        setNeedsAuth(false);
+                        setNeedsAuthentication(false);
                     }
                 }}
                 actionText="delete your account"
@@ -59,10 +57,7 @@ export function SettingsPage() {
             />
 
             {/* Delete Account Dialog - Shows after authentication */}
-            <DeleteAccountDialog
-                open={deleteAccountDialogOpen}
-                onOpenChange={setDeleteAccountDialogOpen}
-            />
+            <DeleteAccountDialog open={deleteAccountDialogOpen} onOpenChange={setDeleteAccountDialogOpen} />
         </>
     );
 }

--- a/source/modules/account/pages/profile/settings/components/DeleteAccount.tsx
+++ b/source/modules/account/pages/profile/settings/components/DeleteAccount.tsx
@@ -4,127 +4,22 @@
 import React from 'react';
 
 // Dependencies - Main Components
-import { Button } from '@structure/source/common/buttons/Button';
-import { EmailVerificationChallenge } from '@structure/source/modules/account/pages/authentication/components/challenges/email-verification/EmailVerificationChallenge';
-import { AccountPasswordChallenge } from '@structure/source/modules/account/pages/authentication/components/challenges/account-password/AccountPasswordChallenge';
+import { AccountMaintenanceSession } from '@structure/source/modules/account/components/AccountMaintenanceSession';
 import { DeleteAccountForm } from '@structure/source/modules/account/pages/profile/settings/components/DeleteAccountForm';
-
-// Dependencies - Account
-import { useAccount } from '@structure/source/modules/account/providers/AccountProvider';
-
-// Dependencies - API
-import { networkService, gql } from '@structure/source/services/network/NetworkService';
-import {
-    AccountAuthenticationQuery,
-    AuthenticationSessionStatus,
-} from '@structure/source/api/graphql/GraphQlGeneratedCode';
 
 // Component - DeleteAccount
 export interface DeleteAccountProperties {
     onComplete?: () => void;
 }
 export function DeleteAccount(properties: DeleteAccountProperties) {
-    // State
-    const [authenticationSession, setAuthenticationSession] = React.useState<
-        AccountAuthenticationQuery['accountAuthentication'] | undefined
-    >(undefined);
-
-    // Hooks
-    const account = useAccount();
-    const emailAddress = account.data?.emailAddress ?? '';
-
-    // Hooks - API - Mutations
-    const accountMaintenanceSessionCreateRequest = networkService.useGraphQlMutation(
-        gql(`
-            mutation AccountMaintenanceSessionCreate {
-                accountMaintenanceSessionCreate {
-                    status
-                    scopeType
-                    currentChallenge {
-                        challengeType
-                        status
-                    }
-                    updatedAt
-                    createdAt
-                }
-            }
-        `),
-    );
-
-    // Function to create the account maintenance session
-    async function createAccountMaintenanceSession() {
-        await accountMaintenanceSessionCreateRequest.execute();
-    }
-
-    // The current authentication component based on the authentication state
-    let currentAuthenticationComponent = null;
-
-    // Authenticated
-    if(
-        // The account maintenance session shows we are authenticated and the scope is AccountMaintenance
-        (accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.status ==
-            AuthenticationSessionStatus.Authenticated &&
-            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.scopeType ==
-                'AccountMaintenance') ||
-        // Or, the current authentication session shows we are authenticated and the scope is AccountMaintenance
-        (authenticationSession?.status == AuthenticationSessionStatus.Authenticated &&
-            authenticationSession?.scopeType == 'AccountMaintenance')
-    ) {
-        currentAuthenticationComponent = <DeleteAccountForm onComplete={properties.onComplete} />;
-    }
-    // Challenged
-    else if(
-        accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.status ==
-        AuthenticationSessionStatus.Challenged
-    ) {
-        // Challenge - Email Verification
-        if(
-            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.currentChallenge
-                ?.challengeType == 'EmailVerification'
-        ) {
-            currentAuthenticationComponent = (
-                <EmailVerificationChallenge
-                    emailAddress={emailAddress}
-                    onSuccess={function (authenticationSession) {
-                        setAuthenticationSession(authenticationSession);
-                    }}
-                />
-            );
-        }
-        // Challenge - Account Password
-        else if(
-            accountMaintenanceSessionCreateRequest.data?.accountMaintenanceSessionCreate.currentChallenge
-                ?.challengeType == 'AccountPassword'
-        ) {
-            currentAuthenticationComponent = (
-                <AccountPasswordChallenge
-                    emailAddress={emailAddress}
-                    onSuccess={function (authenticationSession) {
-                        setAuthenticationSession(authenticationSession);
-                    }}
-                />
-            );
-        }
-    }
-    // Ready to start an authentication session
-    else {
-        currentAuthenticationComponent = (
-            <div>
-                <h2 className="text-base font-medium">Delete Account</h2>
-                <p className="mt-4 text-sm">To delete your account, please verify your identity.</p>
-                <Button
-                    loading={accountMaintenanceSessionCreateRequest.isLoading}
-                    className="mt-6"
-                    onClick={function () {
-                        createAccountMaintenanceSession();
-                    }}
-                >
-                    Continue
-                </Button>
-            </div>
-        );
-    }
-
     // Render the component
-    return <div>{currentAuthenticationComponent}</div>;
+    return (
+        <AccountMaintenanceSession
+            title="Delete Account"
+            description="To delete your account, please verify your identity."
+            buttonText="Continue"
+        >
+            <DeleteAccountForm onComplete={properties.onComplete} />
+        </AccountMaintenanceSession>
+    );
 }

--- a/source/modules/account/pages/profile/settings/components/DeleteAccountDialog.tsx
+++ b/source/modules/account/pages/profile/settings/components/DeleteAccountDialog.tsx
@@ -42,7 +42,7 @@ export function DeleteAccountDialog(properties: DeleteAccountDialogProperties) {
             content={
                 <div>
                     <h2 className="mb-4 text-lg font-semibold text-red-600">Delete Account</h2>
-                    <p className="mb-4 text-sm text-foreground-secondary">
+                    <p className="text-foreground-secondary mb-4 text-sm">
                         This action cannot be undone. All your data will be permanently deleted.
                     </p>
                     <DeleteAccountForm

--- a/source/modules/account/pages/profile/settings/components/DeleteAccountDialog.tsx
+++ b/source/modules/account/pages/profile/settings/components/DeleteAccountDialog.tsx
@@ -6,7 +6,7 @@ import { useRouter } from '@structure/source/router/Navigation';
 
 // Dependencies - Main Components
 import { DialogProperties, Dialog } from '@structure/source/common/dialogs/Dialog';
-import { DeleteAccount } from '@structure/source/modules/account/pages/profile/settings/components/DeleteAccount';
+import { DeleteAccountForm } from '@structure/source/modules/account/pages/profile/settings/components/DeleteAccountForm';
 
 // Component - DeleteAccountDialog
 export type DeleteAccountDialogProperties = DialogProperties;
@@ -37,14 +37,20 @@ export function DeleteAccountDialog(properties: DeleteAccountDialogProperties) {
     // Render the component
     return (
         <Dialog
-            className="p-12"
+            className="p-6"
             accessibilityTitle="Delete Account"
             content={
-                <DeleteAccount
-                    onComplete={function () {
-                        router.push('/');
-                    }}
-                />
+                <div>
+                    <h2 className="mb-4 text-lg font-semibold text-red-600">Delete Account</h2>
+                    <p className="mb-4 text-sm text-foreground-secondary">
+                        This action cannot be undone. All your data will be permanently deleted.
+                    </p>
+                    <DeleteAccountForm
+                        onComplete={function () {
+                            router.push('/');
+                        }}
+                    />
+                </div>
             }
             {...properties}
             // Spread these properties after all properties to ensure they are not overwritten

--- a/source/modules/account/pages/profile/settings/components/DeleteAccountForm.tsx
+++ b/source/modules/account/pages/profile/settings/components/DeleteAccountForm.tsx
@@ -79,9 +79,6 @@ export function DeleteAccountForm(properties: DeleteAccountFormProperties) {
 
             {!success && (
                 <>
-                    <h2 className="text-xl font-medium">Delete Account</h2>
-                    <p className="mt-4">Are you sure you want to delete your account?</p>
-
                     <Form
                         className="mt-6"
                         formInputs={[

--- a/source/modules/account/pages/profile/settings/components/DeleteAccountForm.tsx
+++ b/source/modules/account/pages/profile/settings/components/DeleteAccountForm.tsx
@@ -21,6 +21,9 @@ export interface DeleteAccountFormProperties {
     onComplete?: () => void;
 }
 export function DeleteAccountForm(properties: DeleteAccountFormProperties) {
+    // State
+    const [success, setSuccess] = React.useState(false);
+
     // Hooks
     const accountDeleteRequest = networkService.useGraphQlMutation(
         gql(`
@@ -31,9 +34,6 @@ export function DeleteAccountForm(properties: DeleteAccountFormProperties) {
             }
         `),
     );
-
-    // State
-    const [success, setSuccess] = React.useState(false);
 
     // Function to handle form submission
     async function handleSubmit(formValues: { reason?: string }): Promise<FormSubmitResponseInterface> {

--- a/source/ops/pages/developers/metrics/DataSource.tsx
+++ b/source/ops/pages/developers/metrics/DataSource.tsx
@@ -146,7 +146,15 @@ export function DataSource(properties: DataSourceProperties) {
         },
         {
             enabled: !properties.error && !!columnToMeasure, // Skip if there is an error or if there is no column to measure
-            onSuccess: (data) => {
+        },
+    );
+
+    // Handle success state
+    React.useEffect(
+        function () {
+            if(dataInteractionDatabaseTableMetricsRequest.data) {
+                const data = dataInteractionDatabaseTableMetricsRequest.data;
+
                 // Set the loading state to false
                 properties.setLoading(false);
 
@@ -195,13 +203,21 @@ export function DataSource(properties: DataSourceProperties) {
                         ];
                     }
                 });
-            },
-            onError: function () {
+            }
+        },
+        [dataInteractionDatabaseTableMetricsRequest.data, columnToMeasure, properties],
+    );
+
+    // Handle error state
+    React.useEffect(
+        function () {
+            if(dataInteractionDatabaseTableMetricsRequest.isError) {
                 properties.setDataSourcesWithMetrics((old) => {
                     return old.filter((old) => old.id !== properties.settings.id);
                 });
-            },
+            }
         },
+        [dataInteractionDatabaseTableMetricsRequest.isError, properties],
     );
 
     // Function to handle changing the database and table


### PR DESCRIPTION
Add AccountMaintenanceDialog to make it easier to handle auth session required calls.
- Shows a spinner and makes a check to see if a current auth session is established
- If yes, proceeds directly to the next action that requires auth access
- If no, runs the auth session logic which will ask the user to re-verify themselves either through email verification or password (if set)
<img width="481" height="207" alt="Screenshot 2025-09-16 at 10 23 20 PM" src="https://github.com/user-attachments/assets/8cb0215f-2603-447c-82af-527d60472c1e" />
